### PR TITLE
Fix: black line on unlock indicator

### DIFF
--- a/unlock_indicator.c
+++ b/unlock_indicator.c
@@ -300,7 +300,7 @@ xcb_pixmap_t draw_image(uint32_t *resolution) {
         cairo_move_to(ctx, x, y);
         cairo_show_text(ctx, text);
         cairo_close_path(ctx);
-
+        cairo_move_to(ctx, BUTTON_CENTER + BUTTON_RADIUS - 5, y - time_extents.y_bearing);
         //free(text);
 
         /* Draw an inner seperator line. */


### PR DESCRIPTION
Currently when you press enter or make a mistake the indicator is filled with a color (blue or red), but a black line appears.

After the change the unlock indicator look like this.
![clean](https://cloud.githubusercontent.com/assets/1035974/15009990/1c716056-11ea-11e6-98e5-0d9d85b1885e.jpg)

Before the change it looked like that.
![old_error](https://cloud.githubusercontent.com/assets/1035974/15009991/1c72c734-11ea-11e6-8c90-c3131267b4ae.jpg)

Btw: I'm sorry for the bad quality pictures, but I didn't know how to do a screen capture when locked so I had to use my phone.
